### PR TITLE
Feat: Update primary color

### DIFF
--- a/assets/l10n/en_US.json
+++ b/assets/l10n/en_US.json
@@ -110,6 +110,7 @@
     "preferences.primaryCurrency": "Primary currency",
     "preferences.language": "Language",
     "preferences.language.choose": "Choose language",
+    "preferences.theme.setPrimaryColor": "Set primary color",
     "preferences.themeMode": "Theme",
     "preferences.themeMode.light": "Light",
     "preferences.themeMode.dark": "Dark",

--- a/assets/l10n/mn_MN.json
+++ b/assets/l10n/mn_MN.json
@@ -110,6 +110,7 @@
     "preferences.primaryCurrency": "Үндсэн валют",
     "preferences.language": "Хэл",
     "preferences.language.choose": "Хэл сонгох",
+    "preferences.theme.setPrimaryColor": "Үндсэн өнгө сонгох",
     "preferences.themeMode": "Үзэмж",
     "preferences.themeMode.light": "Гэгээлэг",
     "preferences.themeMode.dark": "Харанхуй",

--- a/lib/prefs.dart
+++ b/lib/prefs.dart
@@ -228,6 +228,31 @@ class LocalPreferences {
     }
   }
 
+  Future<bool> setPrimaryColor(Color? color) async {
+    const prefixKey = "flow.primaryColor";
+
+    if (color == null) {
+      return await _prefs.remove(prefixKey);
+    } else {
+      final colorValue = color.value.toRadixString(16);
+      return await _prefs.setString(
+        prefixKey,
+        colorValue.toString(),
+      );
+    }
+  }
+
+  Future<Color?> getPrimaryColor() async {
+    const prefixKey = "flow.primaryColor";
+    final String? colorString = _prefs.getString(prefixKey);
+
+    if (colorString == null) {
+      return null;
+    }
+
+    return Color(int.parse(colorString, radix: 16) + 0xFF000000);
+  }
+
   String getPrimaryCurrency() {
     String? primaryCurrencyName = primaryCurrency.value;
 

--- a/lib/routes/preferences/language_selection_sheet.dart
+++ b/lib/routes/preferences/language_selection_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flow/l10n/flow_localizations.dart';
+import 'package:flow/theme/theme.dart';
 import 'package:flow/widgets/general/modal_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -33,6 +34,8 @@ class _LanguageSelectionSheetState extends State<LanguageSelectionSheet> {
           children: [
             ...FlowLocalizations.supportedLanguages.map(
               (locale) => ListTile(
+                selectedTileColor: context.colorScheme.primary,
+                selectedColor: context.colorScheme.onPrimary,
                 title: Text(locale.name),
                 onTap: () => context.pop(locale),
                 selected: widget.currentLocale == locale,

--- a/lib/routes/preferences_page.dart
+++ b/lib/routes/preferences_page.dart
@@ -1,3 +1,4 @@
+import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flow/l10n/flow_localizations.dart';
 import 'package:flow/main.dart';
 import 'package:flow/prefs.dart';
@@ -47,6 +48,12 @@ class _PreferencesPageState extends State<PreferencesPage> {
                 onTap: () => updateTheme(),
                 onLongPress: () => updateTheme(ThemeMode.system),
                 trailing: const Icon(Symbols.chevron_right_rounded),
+              ),
+              ListTile(
+                title: Text("preferences.theme.setPrimaryColor".t(context)),
+                leading: const Icon(Icons.color_lens),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => updatePrimaryColor(context),
               ),
               ListTile(
                 title: Text("preferences.language".t(context)),
@@ -145,6 +152,73 @@ class _PreferencesPageState extends State<PreferencesPage> {
     } finally {
       _languageBusy = false;
     }
+  }
+
+  void updatePrimaryColor(BuildContext context) async {
+    if (_themeBusy) return;
+
+    setState(() {
+      _themeBusy = true;
+    });
+
+    try {
+      final selected = await openColorPickerDialog(context);
+      if (selected) {
+        // _openConfirmDialog();
+        Flow.of(context).updatePrimaryColor();
+      }
+    } finally {
+      _themeBusy = false;
+    }
+  }
+
+  Future<bool> openColorPickerDialog(BuildContext context) async {
+    return ColorPicker(
+      // Use the dialogPickerColor as start color.
+      color: context.colorScheme.primary,
+      // Update the dialogPickerColor using the callback.
+      onColorChanged: (Color color) async {
+        await LocalPreferences().setPrimaryColor(color);
+      },
+      width: 40,
+      height: 40,
+      borderRadius: 4,
+      spacing: 5,
+      runSpacing: 5,
+      wheelDiameter: 155,
+      showMaterialName: true,
+      showColorName: true,
+      showColorCode: true,
+      copyPasteBehavior: const ColorPickerCopyPasteBehavior(
+        longPressMenu: true,
+        copyButton: true,
+        pasteButton: true,
+      ),
+      materialNameTextStyle: Theme.of(context).textTheme.bodySmall,
+      colorNameTextStyle: Theme.of(context).textTheme.bodySmall,
+      colorCodeTextStyle: Theme.of(context).textTheme.bodySmall,
+      pickersEnabled: const <ColorPickerType, bool>{
+        ColorPickerType.wheel: true,
+        ColorPickerType.accent: false,
+      },
+    ).showPickerDialog(
+      context,
+      transitionBuilder: (BuildContext context, Animation<double> a1,
+          Animation<double> a2, Widget widget) {
+        final double curvedValue =
+            Curves.easeInOutBack.transform(a1.value) - 1.0;
+        return Transform(
+          transform: Matrix4.translationValues(0.0, curvedValue * 200, 0.0),
+          child: Opacity(
+            opacity: a1.value,
+            child: widget,
+          ),
+        );
+      },
+      transitionDuration: const Duration(milliseconds: 400),
+      constraints:
+          const BoxConstraints(minHeight: 460, minWidth: 300, maxWidth: 320),
+    );
   }
 
   void updatePrimaryCurrency() async {

--- a/lib/routes/preferences_page.dart
+++ b/lib/routes/preferences_page.dart
@@ -186,8 +186,6 @@ class _PreferencesPageState extends State<PreferencesPage> {
       spacing: 5,
       runSpacing: 5,
       wheelDiameter: 155,
-      showMaterialName: true,
-      showColorName: true,
       showColorCode: true,
       copyPasteBehavior: const ColorPickerCopyPasteBehavior(
         longPressMenu: true,

--- a/lib/routes/preferences_page.dart
+++ b/lib/routes/preferences_page.dart
@@ -188,18 +188,16 @@ class _PreferencesPageState extends State<PreferencesPage> {
       wheelDiameter: 155,
       showColorCode: true,
       copyPasteBehavior: const ColorPickerCopyPasteBehavior(
-        longPressMenu: true,
         copyButton: true,
         pasteButton: true,
       ),
-      materialNameTextStyle: Theme.of(context).textTheme.bodySmall,
-      colorNameTextStyle: Theme.of(context).textTheme.bodySmall,
-      colorCodeTextStyle: Theme.of(context).textTheme.bodySmall,
       pickersEnabled: const <ColorPickerType, bool>{
         ColorPickerType.wheel: true,
         ColorPickerType.accent: false,
       },
     ).showPickerDialog(
+      backgroundColor: context.colorScheme.surface,
+      surfaceTintColor: context.colorScheme.primary,
       context,
       transitionBuilder: (BuildContext context, Animation<double> a1,
           Animation<double> a2, Widget widget) {

--- a/lib/widgets/account_card.dart
+++ b/lib/widgets/account_card.dart
@@ -39,6 +39,7 @@ class AccountCard extends StatelessWidget {
         : account.transactions.expenseSum;
 
     final child = Surface(
+      color: context.colorScheme.surface,
       shape: RoundedRectangleBorder(borderRadius: borderRadius),
       builder: (context) => InkWell(
         onTap: onTapOverride == null

--- a/lib/widgets/account_card_skeleton.dart
+++ b/lib/widgets/account_card_skeleton.dart
@@ -16,6 +16,7 @@ class AccountCardSkeleton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Surface(
+      color: context.colorScheme.primary,
       shape: RoundedRectangleBorder(borderRadius: borderRadius),
       builder: (context) => InkWell(
         onTap: onTap,

--- a/lib/widgets/action_card.dart
+++ b/lib/widgets/action_card.dart
@@ -22,6 +22,7 @@ class ActionCard extends StatelessWidget {
     return SizedBox(
       width: double.infinity,
       child: Surface(
+        color: Theme.of(context).colorScheme.primary,
         shape: RoundedRectangleBorder(
           borderRadius: borderRadius,
         ),

--- a/lib/widgets/add_category_card.dart
+++ b/lib/widgets/add_category_card.dart
@@ -1,5 +1,6 @@
 import 'package:flow/data/flow_icon.dart';
 import 'package:flow/l10n/extensions.dart';
+import 'package:flow/theme/theme.dart';
 import 'package:flow/widgets/general/flow_icon.dart';
 import 'package:flow/widgets/general/surface.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +20,7 @@ class AddCategoryCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Surface(
+      color: context.colorScheme.surface,
       shape: RoundedRectangleBorder(borderRadius: borderRadius),
       builder: (context) => InkWell(
         borderRadius: borderRadius,

--- a/lib/widgets/category_card.dart
+++ b/lib/widgets/category_card.dart
@@ -31,6 +31,7 @@ class CategoryCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Surface(
+      color: context.colorScheme.surface,
       shape: RoundedRectangleBorder(borderRadius: borderRadius),
       builder: (context) => InkWell(
         borderRadius: borderRadius,

--- a/lib/widgets/general/button.dart
+++ b/lib/widgets/general/button.dart
@@ -61,7 +61,7 @@ class Button extends StatelessWidget {
 
     return Surface(
       shape: RoundedRectangleBorder(borderRadius: borderRadius),
-      // color: backgroundColor ?? context.colorScheme.primary,
+      color: backgroundColor ?? context.colorScheme.primary,
       builder: (context) => InkWell(
         onTap: onTap,
         onLongPress: onLongPress,

--- a/lib/widgets/general/flow_icon.dart
+++ b/lib/widgets/general/flow_icon.dart
@@ -49,7 +49,7 @@ class FlowIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     if (!plated) return buildChild(context, data);
 
-    final plateColor = this.plateColor ?? context.colorScheme.secondary;
+    final plateColor = this.plateColor ?? context.colorScheme.onSurface;
 
     return Surface(
       builder: (BuildContext context) => InkWell(

--- a/lib/widgets/numpad_button.dart
+++ b/lib/widgets/numpad_button.dart
@@ -42,7 +42,7 @@ class NumpadButton extends StatelessWidget {
       child: Material(
         textStyle: DefaultTextStyle.of(context).style,
         type: MaterialType.button,
-        color: backgroundColor ?? context.colorScheme.secondary,
+        color: backgroundColor ?? context.colorScheme.primary,
         borderRadius: borderRadius,
         child: InkWell(
           borderRadius: borderRadius,

--- a/lib/widgets/select_currency_sheet.dart
+++ b/lib/widgets/select_currency_sheet.dart
@@ -90,6 +90,8 @@ class _SelectCurrencySheetState extends State<SelectCurrencySheet> {
 
           return ListTile(
             selected: widget.currentlySelected == transformedCurrencyData.code,
+            selectedTileColor: context.colorScheme.primary,
+            selectedColor: context.colorScheme.onPrimary,
             title: Text(
               transformedCurrencyData.name,
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -345,6 +345,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  flex_color_picker:
+    dependency: "direct main"
+    description:
+      name: flex_color_picker
+      sha256: "5c846437069fb7afdd7ade6bf37e628a71d2ab0787095ddcb1253bf9345d5f3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: "29c12aba221eb8a368a119685371381f8035011d18de5ba277ad11d7dfb8657f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   file_picker: ^6.1.1
   file_saver: ^0.2.9
   fl_chart: ^0.66.2
+  flex_color_picker: ^3.4.1
   flutter:
     sdk: flutter
   flutter_floating_bottom_bar: ^1.2.0


### PR DESCRIPTION
Hello @sadespresso, I have refactored my code to implement #105. Please do check it out.

I have found a small quirk with regards to keeping the primary color on the local storage though. Android seems to backup local storage - and by extension, the primary color - for devices with android API >= 23 even after uninstalls. There is a [way](https://stackoverflow.com/questions/57302477/flutter-not-clearing-data-even-after-installing-uninstalling-app) to clear them by editing the AndroidManifest.xml file. 

Let me know what your preference is with regards to this.

Thanks!