### PR TITLE
Upcoming transactions config doesn’t get set initially

### DIFF
--- a/lib/routes/home/home_tab.dart
+++ b/lib/routes/home/home_tab.dart
@@ -54,6 +54,7 @@ class _HomeTabState extends State<HomeTab> with AutomaticKeepAliveClientMixin {
   void initState() {
     super.initState();
     noTransactionsAtAll = ObjectBox().box<Transaction>().count(limit: 1) == 0;
+    _updatePlannedTransactionDays();
     LocalPreferences()
         .homeTabPlannedTransactionsDays
         .addListener(_updatePlannedTransactionDays);


### PR DESCRIPTION
Fixes #187