### PR TITLE
Refactor: Normalize country/region name to common usage

### DIFF
--- a/lib/services/currency_registry.dart
+++ b/lib/services/currency_registry.dart
@@ -676,7 +676,7 @@ class CurrencyRegistryService {
       code: "SYP",
     ),
     const CurrencyData(
-      country: "TAIWAN (PROVINCE OF CHINA)",
+      country: "TAIWAN",
       name: "New Taiwan Dollar",
       code: "TWD",
     ),


### PR DESCRIPTION
Hello! First off, I want to express my sincere appreciation to the author(s) for this project. It's truly fantastic work, and I'm a big fan.

This PR proposes updating the country/region display name from "TAIWAN (PROVINCE OF CHINA)" to "TAIWAN".

The primary justification for this change is to align our application with the **Unicode CLDR (Common Locale Data Repository)** standard. CLDR is the industry best practice for all user-facing localization and internationalization (i18n).

* **Reference:** As shown in the official CLDR data, the standard display name for the `TW` territory code is **"Taiwan"**.
    * [CLDR v48 Territory Language Information](https://www.unicode.org/cldr/charts/48/supplemental/territory_language_information.html)