### PR TITLE
fix: TwoEntryLast widget shows last 2 buttons instead of first 2

### DIFF
--- a/android/app/src/main/kotlin/mn/flow/flow/glance/TwoEntryLast.kt
+++ b/android/app/src/main/kotlin/mn/flow/flow/glance/TwoEntryLast.kt
@@ -44,7 +44,7 @@ class TwoEntryLast : GlanceAppWidget() {
 @Composable
 @Preview(widthDp = 100, heightDp = 50)
 private fun Content(context: Context, currentState: HomeWidgetGlanceState) {
-  val buttonOrder = FlowWidgetUtils.getButtonOrder(currentState.preferences).subList(0, 2)
+  val buttonOrder = FlowWidgetUtils.getButtonOrder(currentState.preferences).takeLast(2)
 
   val size = LocalSize.current
   val buttonSize = min((size.width / 2 - 24.dp), (size.height - 16.dp))


### PR DESCRIPTION
## Summary

Fixes #697

The `TwoEntryLast` widget was using `.subList(0, 2)` which returns the **first** two buttons from the user's button order — the same as the regular `TwoEntry` widget. This made both widgets display identical buttons.

## Change

Changed `.subList(0, 2)` to `.takeLast(2)` in `TwoEntryLast.kt` so the widget correctly shows the **last** two buttons from the configured order.

## Testing

Tested on Pixel 8 Pro (Android 16). The widget now correctly displays the last two buttons instead of duplicating the first two.