### PR TITLE
Adds a summary home screen widget displaying the current month's total income and expenses — available on both iOS and Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## next
+
+### New features
+
+* Added summary home screen widget showing monthly income and expenses (iOS + Android)
+
 ## 0.20.0
 
 ### New features

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -106,6 +106,16 @@
         android:name="android.appwidget.provider"
         android:resource="@xml/four_entry_widget_info" />
     </receiver>
+    <receiver
+      android:name=".glance.SummaryReceiver"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/summary_widget_info" />
+    </receiver>
     <provider
       android:name="androidx.core.content.FileProvider"
       android:authorities="${applicationId}.provider"

--- a/android/app/src/main/kotlin/mn/flow/flow/glance/Summary.kt
+++ b/android/app/src/main/kotlin/mn/flow/flow/glance/Summary.kt
@@ -1,0 +1,144 @@
+package mn.flow.flow.glance
+
+import es.antonborri.home_widget.HomeWidgetGlanceState
+import es.antonborri.home_widget.HomeWidgetGlanceStateDefinition
+import android.content.Context
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.currentState
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
+import androidx.glance.state.GlanceStateDefinition
+import androidx.glance.ColorFilter
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import mn.flow.flow.MainActivity
+import mn.flow.flow.R
+
+class Summary : GlanceAppWidget() {
+  override val sizeMode = SizeMode.Exact
+
+  override val stateDefinition: GlanceStateDefinition<*>
+    get() = HomeWidgetGlanceStateDefinition()
+
+  override suspend fun provideGlance(context: Context, id: GlanceId) {
+    provideContent {
+      GlanceTheme {
+        Content(context, currentState())
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalGlancePreviewApi::class)
+@Composable
+@Preview(widthDp = 200, heightDp = 100)
+private fun Content(context: Context, currentState: HomeWidgetGlanceState) {
+  val income = currentState.preferences.getString("summaryIncome", null) ?: "---"
+  val expense = currentState.preferences.getString("summaryExpense", null) ?: "---"
+  val incomeLabel = currentState.preferences.getString("summaryIncomeLabel", null) ?: "Income"
+  val expenseLabel = currentState.preferences.getString("summaryExpenseLabel", null) ?: "Expense"
+
+  Box(
+    modifier = GlanceModifier
+      .background(GlanceTheme.colors.widgetBackground)
+      .fillMaxSize()
+      .clickable(
+        onClick = actionStartActivity(
+          Intent(context, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+          }
+        )
+      ),
+    contentAlignment = Alignment.Center
+  ) {
+    Row(
+      modifier = GlanceModifier.padding(8.dp).fillMaxSize(),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Box(modifier = GlanceModifier.defaultWeight()) {
+        SummaryCard(
+          label = incomeLabel,
+          iconRes = R.drawable.ic_arrow_down_forward,
+          amount = income,
+          accentColor = ColorProvider(R.color.income_green),
+        )
+      }
+      Spacer(modifier = GlanceModifier.width(8.dp))
+      Box(modifier = GlanceModifier.defaultWeight()) {
+        SummaryCard(
+          label = expenseLabel,
+          iconRes = R.drawable.ic_arrow_up_forward,
+          amount = expense,
+          accentColor = ColorProvider(R.color.expense_red),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun SummaryCard(label: String, iconRes: Int, amount: String, accentColor: ColorProvider) {
+  Box(
+    modifier = GlanceModifier
+      .fillMaxWidth()
+      .background(GlanceTheme.colors.surfaceVariant)
+      .cornerRadius(16.dp)
+      .padding(horizontal = 16.dp, vertical = 12.dp),
+  ) {
+    Column {
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+          text = label,
+          style = TextStyle(
+            color = GlanceTheme.colors.onSurfaceVariant,
+            fontSize = 13.sp,
+          ),
+        )
+        Spacer(modifier = GlanceModifier.width(4.dp))
+        Image(
+          provider = ImageProvider(iconRes),
+          contentDescription = null,
+          modifier = GlanceModifier.width(20.dp).height(20.dp),
+          colorFilter = ColorFilter.tint(accentColor),
+        )
+      }
+      Spacer(modifier = GlanceModifier.height(4.dp))
+      Text(
+        text = amount,
+        style = TextStyle(
+          color = GlanceTheme.colors.onSurface,
+          fontSize = 20.sp,
+          fontWeight = FontWeight.Bold,
+        ),
+        maxLines = 1,
+      )
+    }
+  }
+}

--- a/android/app/src/main/kotlin/mn/flow/flow/glance/SummaryReceiver.kt
+++ b/android/app/src/main/kotlin/mn/flow/flow/glance/SummaryReceiver.kt
@@ -1,0 +1,8 @@
+package mn.flow.flow.glance
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class SummaryReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = Summary()
+}

--- a/android/app/src/main/res/drawable/ic_arrow_down_forward.xml
+++ b/android/app/src/main/res/drawable/ic_arrow_down_forward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:pathData="M480,647 L636,492 Q647,481 663.5,480.5 Q680,480 692,492 Q703,503 703,520 Q703,537 692,548 L537,703 Q514,726 480,726 Q446,726 423,703 L268,548 Q257,537 256.5,520.5 Q256,504 268,492 Q279,481 296,481 Q313,481 324,492 Z M480,407 L636,252 Q647,241 663.5,240.5 Q680,240 692,252 Q703,263 703,280 Q703,297 692,308 L537,463 Q514,486 480,486 Q446,486 423,463 L268,308 Q257,297 256.5,280.5 Q256,264 268,252 Q279,241 296,241 Q313,241 324,252 Z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_arrow_up_forward.xml
+++ b/android/app/src/main/res/drawable/ic_arrow_up_forward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:pathData="M480,553 L324,708 Q313,719 296.5,719.5 Q280,720 268,708 Q257,697 257,680 Q257,663 268,652 L423,497 Q446,474 480,474 Q514,474 537,497 L692,652 Q703,663 703.5,679.5 Q704,696 692,708 Q681,719 664,719 Q647,719 636,708 Z M480,313 L324,468 Q313,479 296.5,479.5 Q280,480 268,468 Q257,457 257,440 Q257,423 268,412 L423,257 Q446,234 480,234 Q514,234 537,257 L692,412 Q703,423 703.5,439.5 Q704,456 692,468 Q681,479 664,479 Q647,479 636,468 Z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/android/app/src/main/res/values-night/widget_colors.xml
+++ b/android/app/src/main/res/values-night/widget_colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="income_green">#FF32CC70</color>
+    <color name="expense_red">#FFFF4040</color>
+</resources>

--- a/android/app/src/main/res/values/widget_colors.xml
+++ b/android/app/src/main/res/values/widget_colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="income_green">#FF32CC70</color>
+    <color name="expense_red">#FFFF4040</color>
+</resources>

--- a/android/app/src/main/res/xml/summary_widget_info.xml
+++ b/android/app/src/main/res/xml/summary_widget_info.xml
@@ -1,0 +1,10 @@
+<appwidget-provider
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:label="Flow Summary"
+  android:minWidth="180dp"
+  android:minHeight="55dp"
+  android:targetCellWidth="3"
+  android:targetCellHeight="1"
+  android:resizeMode="horizontal"
+  android:initialLayout="@layout/glance_default_loading_layout">
+</appwidget-provider>

--- a/ios/Flow Widgets/LeBundle.swift
+++ b/ios/Flow Widgets/LeBundle.swift
@@ -12,5 +12,6 @@ import SwiftUI
 struct LeBundle: WidgetBundle {
     var body: some Widget {
         FlowTwoEntryWidget()
+        FlowSummaryWidget()
     }
 }

--- a/ios/Flow Widgets/SummaryWidget.swift
+++ b/ios/Flow Widgets/SummaryWidget.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import WidgetKit
+
+struct SummaryWidgetEntry: TimelineEntry {
+    let date: Date
+    let income: String
+    let expense: String
+    let incomeLabel: String
+    let expenseLabel: String
+}
+
+struct SummaryProvider: TimelineProvider {
+    typealias Entry = SummaryWidgetEntry
+
+    func placeholder(in context: Context) -> SummaryWidgetEntry {
+        SummaryWidgetEntry(date: Date(), income: "---", expense: "---", incomeLabel: "Income", expenseLabel: "Expense")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SummaryWidgetEntry) -> ()) {
+        let prefs = UserDefaults(suiteName: "group.mn.flow.flow")
+        let income = prefs?.string(forKey: "summaryIncome") ?? "---"
+        let expense = prefs?.string(forKey: "summaryExpense") ?? "---"
+        let incomeLabel = prefs?.string(forKey: "summaryIncomeLabel") ?? "Income"
+        let expenseLabel = prefs?.string(forKey: "summaryExpenseLabel") ?? "Expense"
+        let entry = SummaryWidgetEntry(date: Date(), income: income, expense: expense, incomeLabel: incomeLabel, expenseLabel: expenseLabel)
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        getSnapshot(in: context) { (entry) in
+            let timeline = Timeline(entries: [entry], policy: .atEnd)
+            completion(timeline)
+        }
+    }
+}
+
+struct SummaryWidgetView: View {
+    var entry: SummaryWidgetEntry
+
+    var body: some View {
+        HStack(spacing: 8) {
+            summaryCard(
+                label: entry.incomeLabel,
+                amount: entry.income,
+                icon: "Income",
+                color: .green
+            )
+            summaryCard(
+                label: entry.expenseLabel,
+                amount: entry.expense,
+                icon: "Expense",
+                color: .red
+            )
+        }
+        .padding(12)
+    }
+
+    @ViewBuilder
+    func summaryCard(label: String, amount: String, icon: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Image(icon)
+                    .resizable()
+                    .renderingMode(.template)
+                    .foregroundStyle(color)
+                    .frame(width: 14, height: 14)
+            }
+            Text(amount)
+                .font(.system(.title3, design: .rounded, weight: .semibold))
+                .foregroundStyle(.primary)
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+struct FlowSummaryWidget: Widget {
+    let kind: String = "FlowSummaryWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(
+            kind: kind, provider: SummaryProvider()
+        ) { entry in
+            SummaryWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .supportedFamilies([.systemSmall, .systemMedium])
+        .configurationDisplayName("Flow Summary")
+        .description("View your monthly income and expenses at a glance.")
+    }
+}
+
+#Preview(as: .systemSmall) {
+    FlowSummaryWidget()
+} timeline: {
+    SummaryWidgetEntry(date: .now, income: "$3.82K", expense: "$1.24K", incomeLabel: "Income", expenseLabel: "Expense")
+}
+
+#Preview(as: .systemMedium) {
+    FlowSummaryWidget()
+} timeline: {
+    SummaryWidgetEntry(date: .now, income: "$3.82K", expense: "$1.24K", incomeLabel: "Income", expenseLabel: "Expense")
+}

--- a/lib/l10n/flow_localizations.dart
+++ b/lib/l10n/flow_localizations.dart
@@ -1,6 +1,7 @@
 import "dart:convert";
 
 import "package:flow/l10n/supported_languages.dart";
+import "package:flow/services/widget_summary_sync.dart";
 import "package:flutter/services.dart";
 import "package:flutter/widgets.dart";
 import "package:logging/logging.dart";
@@ -136,6 +137,7 @@ class _FlowLocalizationDelegate
           : FlowLocalizations.supportedLocales[1],
     );
     await localization.load();
+    WidgetSummarySync.sync();
     return localization;
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ import "package:flow/services/recurring_transactions.dart";
 import "package:flow/services/sync.dart";
 import "package:flow/services/transactions.dart";
 import "package:flow/services/user_preferences.dart";
+import "package:flow/services/widget_summary_sync.dart";
 import "package:flow/theme/color_themes/registry.dart";
 import "package:flow/theme/flow_color_scheme.dart";
 import "package:flow/theme/theme.dart";
@@ -149,6 +150,8 @@ void main() async {
     );
   }
 
+  TransactionsService().addListener(() => WidgetSummarySync.sync());
+
   try {
     Moment.minValue = DateTime(0);
     Moment.maxValue = DateTime(4000);
@@ -199,6 +202,9 @@ class FlowState extends State<Flow> {
 
     UserPreferencesService().valueNotifier.addListener(_reloadTheme);
     UserPreferencesService().valueNotifier.addListener(_listenToShakes);
+    UserPreferencesService().valueNotifier.addListener(_syncWidgets);
+
+    ExchangeRatesService().exchangeRatesCache.addListener(_syncWidgets);
 
     LocalPreferences().localeOverride.addListener(_reloadLocale);
     LocalPreferences().primaryCurrency.addListener(_refreshExchangeRates);
@@ -251,6 +257,9 @@ class FlowState extends State<Flow> {
     LocalPreferences().primaryCurrency.removeListener(_refreshExchangeRates);
     UserPreferencesService().valueNotifier.removeListener(_reloadTheme);
     UserPreferencesService().valueNotifier.removeListener(_listenToShakes);
+    UserPreferencesService().valueNotifier.removeListener(_syncWidgets);
+
+    ExchangeRatesService().exchangeRatesCache.removeListener(_syncWidgets);
 
     TransactionsService().removeListener(_synchronizePlannedNotifications);
 
@@ -424,6 +433,10 @@ class FlowState extends State<Flow> {
     ExchangeRatesService().tryFetchRates(
       UserPreferencesService().primaryCurrency,
     );
+  }
+
+  void _syncWidgets() {
+    WidgetSummarySync.sync();
   }
 
   void _synchronizePlannedNotifications() {

--- a/lib/routes/home/stats_tab.dart
+++ b/lib/routes/home/stats_tab.dart
@@ -62,11 +62,13 @@ class _StatsTabState extends State<StatsTab>
 
     rates = ExchangeRatesService().getPrimaryCurrencyRates();
     ExchangeRatesService().exchangeRatesCache.addListener(_updateRates);
+    UserPreferencesService().valueNotifier.addListener(_updateRates);
   }
 
   @override
   void dispose() {
     ExchangeRatesService().exchangeRatesCache.removeListener(_updateRates);
+    UserPreferencesService().valueNotifier.removeListener(_updateRates);
     super.dispose();
   }
 

--- a/lib/services/user_preferences.dart
+++ b/lib/services/user_preferences.dart
@@ -16,6 +16,7 @@ import "package:flow/services/currency_registry.dart";
 import "package:flow/services/integrations/eny.dart";
 import "package:flow/services/notifications.dart";
 import "package:flow/services/sync.dart";
+import "package:flow/services/widget_summary_sync.dart";
 import "package:flow/theme/color_themes/registry.dart";
 import "package:flutter/material.dart";
 import "package:home_widget/home_widget.dart";
@@ -464,6 +465,7 @@ class UserPreferencesService {
           .then((_) {
             ensurePrimaryAccountAvailability();
             _updateButtonsWidgets(transactionButtonOrder);
+            WidgetSummarySync.sync();
           })
           .catchError((e) {
             _log.warning("Failed to update widgets button order on init: $e");

--- a/lib/services/widget_summary_sync.dart
+++ b/lib/services/widget_summary_sync.dart
@@ -1,0 +1,74 @@
+import "dart:io";
+
+import "package:flow/constants.dart";
+import "package:flow/data/exchange_rates.dart";
+import "package:flow/data/single_currency_flow.dart";
+import "package:flow/entity/transaction.dart";
+import "package:flow/l10n/named_enum.dart";
+import "package:flow/objectbox.dart";
+import "package:flow/objectbox/actions.dart";
+import "package:flow/services/exchange_rates.dart";
+import "package:flow/services/user_preferences.dart";
+import "package:home_widget/home_widget.dart";
+import "package:logging/logging.dart";
+import "package:moment_dart/moment_dart.dart";
+
+final Logger _log = Logger("WidgetSummarySync");
+
+class WidgetSummarySync {
+  static Future<void> sync() async {
+    try {
+      final String primaryCurrency =
+          UserPreferencesService().primaryCurrency;
+      final ExchangeRates? rates =
+          ExchangeRatesService().getPrimaryCurrencyRates();
+
+      final TimeRange range = TimeRange.thisMonth();
+
+      final List<Transaction> transactions = await ObjectBox()
+          .transcationsByRange(range, includeTransfers: false);
+
+      final now = DateTime.now();
+
+      final SingleCurrencyFlow flow =
+          SingleCurrencyFlow(currency: primaryCurrency)
+            ..addAll(
+              transactions
+                  .where((t) => !t.transactionDate.isAfter(now))
+                  .where((t) => t.isPending != true)
+                  .map((t) => t.money),
+              rates,
+            );
+
+      final String formattedIncome =
+          flow.totalIncome.formatMoney(compact: true);
+      final String formattedExpense =
+          flow.totalExpense.abs().formatMoney(compact: true);
+
+      final String incomeLabel = TransactionType.income.localizedName;
+      final String expenseLabel = TransactionType.expense.localizedName;
+
+      if (Platform.isIOS) {
+        await HomeWidget.setAppGroupId(iOSAppGroupId);
+      }
+
+      await HomeWidget.saveWidgetData("summaryIncome", formattedIncome);
+      await HomeWidget.saveWidgetData("summaryExpense", formattedExpense);
+      await HomeWidget.saveWidgetData("summaryIncomeLabel", incomeLabel);
+      await HomeWidget.saveWidgetData("summaryExpenseLabel", expenseLabel);
+
+      await HomeWidget.updateWidget(
+        name: "FlowSummaryWidget",
+        iOSName: "FlowSummaryWidget",
+        androidName: "SummaryReceiver",
+        qualifiedAndroidName: "mn.flow.flow.glance.SummaryReceiver",
+      );
+
+      _log.finest(
+        "Synced summary widget: income=$formattedIncome, expense=$formattedExpense",
+      );
+    } catch (e) {
+      _log.warning("Failed to sync summary widget: $e");
+    }
+  }
+}

--- a/lib/widgets/home/home/account/total_balance.dart
+++ b/lib/widgets/home/home/account/total_balance.dart
@@ -5,6 +5,7 @@ import "package:flow/objectbox/actions.dart";
 import "package:flow/prefs/local_preferences.dart";
 import "package:flow/services/exchange_rates.dart";
 import "package:flow/services/transactions.dart";
+import "package:flow/services/user_preferences.dart";
 import "package:flow/theme/theme.dart";
 import "package:flow/widgets/general/money_text.dart";
 import "package:flutter/material.dart";
@@ -25,6 +26,7 @@ class _TotalBalanceState extends State<TotalBalance> {
   void initState() {
     super.initState();
     LocalPreferences().primaryCurrency.addListener(_refresh);
+    UserPreferencesService().valueNotifier.addListener(_refresh);
     ExchangeRatesService().exchangeRatesCache.addListener(_refresh);
 
     TransactionsService().addListener(_refresh);
@@ -37,6 +39,7 @@ class _TotalBalanceState extends State<TotalBalance> {
   @override
   void dispose() {
     LocalPreferences().primaryCurrency.removeListener(_refresh);
+    UserPreferencesService().valueNotifier.removeListener(_refresh);
     ExchangeRatesService().exchangeRatesCache.removeListener(_refresh);
 
     TransactionsService().removeListener(_refresh);

--- a/lib/widgets/home/stats/most_spending_category.dart
+++ b/lib/widgets/home/stats/most_spending_category.dart
@@ -47,6 +47,13 @@ class _MostSpendingCategoryState extends State<MostSpendingCategory> {
     super.initState();
     range = widget.range;
     fetch();
+    UserPreferencesService().valueNotifier.addListener(fetch);
+  }
+
+  @override
+  void dispose() {
+    UserPreferencesService().valueNotifier.removeListener(fetch);
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
Closes #699

## Changes

### New: Summary Widget
- **Dart** (`widget_summary_sync.dart`): Calculates current month income/expense via ObjectBox + SingleCurrencyFlow, formats with `Money.formatMoney(compact: true)`, syncs localized labels and amounts to native widgets via `home_widget`
- **Android** (`Summary.kt`): Jetpack Glance widget with Material You dynamic theming (`GlanceTheme.colors`), exact Material Symbols icon glyphs extracted from `MaterialSymbolsRounded.ttf`, horizontal-only resize (3×1 cells)
- **iOS** (`SummaryWidget.swift`): WidgetKit SwiftUI widget (`.systemSmall` + `.systemMedium`), uses existing asset catalog icons with template rendering

### Widget behavior
- Reactive to: transaction changes, currency changes, exchange rate updates, and locale changes
- Filters out future transactions and pending transactions
- Expense amounts are displayed as **absolute values** (no minus sign) — this looks cleaner in a compact widget context compared to the main app screen where expenses show with a minus
- Tapping the widget opens the app

### Bug fixes: currency change reactivity
- `StatsTab`: now listens to `UserPreferencesService().valueNotifier` for currency changes
- `TotalBalance`: added `UserPreferencesService().valueNotifier` listener (was only listening to deprecated `LocalPreferences().primaryCurrency`)
- `MostSpendingCategory`: added `UserPreferencesService().valueNotifier` listener + proper `dispose()`
- Widget labels sync after locale is fully loaded (fix in `_FlowLocalizationDelegate.load()`)

## Screenshots & Video

<img width="360" alt="Dark mode, Polish, PLN" src="https://github.com/user-attachments/assets/644ed0b5-b432-4b77-8029-53e9ec0dcbdc" />
<img width="360" alt="Dark mode, English, EUR" src="https://github.com/user-attachments/assets/4fca42b0-e5fd-4034-b1e2-f19855ceed02" />
<img width="360" alt="Light mode, English, EUR" src="https://github.com/user-attachments/assets/dc62aae6-a367-4589-a121-f5fcece2e845" />

https://github.com/user-attachments/assets/b307f6e0-6392-437d-9b81-62ae8b773a87