### PR TITLE
fix: use correct localization key for external source setting

### DIFF
--- a/lib/routes/preferences/transaction_list_item_appearance_preferences_page.dart
+++ b/lib/routes/preferences/transaction_list_item_appearance_preferences_page.dart
@@ -92,7 +92,7 @@ class _TransactionListItemAppearancePreferencesPageState
               ),
               SwitchListTile(
                 title: Text(
-                  "preferences.transactions.listTile.transactionListTileShowExternalSource"
+                  "preferences.transactions.listTile.showExternalSource"
                       .t(context),
                 ),
                 value: transactionListTileShowExternalSource,


### PR DESCRIPTION
## Summary

Fixes the wrong localization key used for the "Show external sources" toggle in the list tile appearance preferences page.

## Problem

The code referenced `preferences.transactions.listTile.transactionListTileShowExternalSource` but the localization files (`en.json` and all language files) define the key as `preferences.transactions.listTile.showExternalSource`. This caused the raw key to be displayed instead of translated text in **all languages**.

## Changes

- Changed the localization key in `transaction_list_item_appearance_preferences_page.dart` from `transactionListTileShowExternalSource` to `showExternalSource`

Fixes #708