### PR TITLE
Fix Android release build on Flutter 3.47

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.0.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.10" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.1.10" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
 }
 
 include(":app")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A personal finance managing app
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: "0.24.0+356"
+version: "0.24.0+357"
 
 environment:
     sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
The beta deploy for 0.24.0 failed on Android. Nothing in the tree caused
it: the workflow pins `channel: stable`, not a version, and stable moved
to Flutter 3.47.2, which raises the minimum supported Kotlin to 2.2.20.

```
Your project's Kotlin version (2.2.10) is lower than Flutter's
minimum supported version of 2.2.20.
```

iOS built and uploaded fine on the same runner set — only the Gradle
path enforces this check.

## Changes

* Kotlin Gradle plugin 2.1.10 → 2.2.20, and the compose compiler plugin
  in lockstep, since the two are versioned together.
* Build number to 357. 356 reached App Store Connect from the iOS half of
  the failed push, so it can't be reused when both workflows re-run.

## Verified locally

* `flutter build apk --debug` — Glance/Compose widget code compiles
* `flutter build appbundle --release --no-tree-shake-icons` — runs
  through `minifyReleaseWithR8` (fresh `mapping.txt`) and stops at
  `signReleaseBundle`, which is as far as it goes without the keystore
