### PR TITLE
RC for 0.24.0 (retry)

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.0.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.10" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.1.10" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" apply false
 }
 
 include(":app")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A personal finance managing app
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: "0.24.0+356"
+version: "0.24.0+357"
 
 environment:
     sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
Retry of the 0.24.0 beta deploy at `0.24.0+357`.

The first attempt shipped iOS 356 to TestFlight but failed on Android:
Flutter stable moved to 3.47.2, which requires Kotlin >= 2.2.20. Fixed in
#755. Build number moved to 357 so both platforms can upload cleanly.
